### PR TITLE
Готовая работа к Уроку №3

### DIFF
--- a/app/src/main/java/q4/test_coverage/mytests/presenter/PresenterContract.kt
+++ b/app/src/main/java/q4/test_coverage/mytests/presenter/PresenterContract.kt
@@ -1,3 +1,10 @@
 package q4.test_coverage.mytests.presenter
 
-internal interface PresenterContract {}
+import q4.test_coverage.mytests.view.ViewContract
+
+internal interface PresenterContract {
+
+    fun onAttach(viewContract: ViewContract)
+
+    fun onDetach(viewContract: ViewContract)
+}

--- a/app/src/main/java/q4/test_coverage/mytests/presenter/details/DetailsPresenter.kt
+++ b/app/src/main/java/q4/test_coverage/mytests/presenter/details/DetailsPresenter.kt
@@ -1,11 +1,16 @@
 package q4.test_coverage.mytests.presenter.details
 
+import android.util.Log
+import q4.test_coverage.mytests.view.ViewContract
 import q4.test_coverage.mytests.view.details.ViewDetailsContract
 
 internal class DetailsPresenter internal constructor(
-    private val viewContract: ViewDetailsContract,
     private var count: Int = 0
 ) : PresenterDetailsContract {
+
+    private val tag = "myLogs"
+
+    private var viewContract: ViewDetailsContract? = null
 
     override fun setCounter(count: Int) {
         this.count = count
@@ -13,11 +18,27 @@ internal class DetailsPresenter internal constructor(
 
     override fun onIncrement() {
         count++
-        viewContract.setCount(count)
+        viewContract?.setCount(count)
     }
 
     override fun onDecrement() {
         count--
-        viewContract.setCount(count)
+        viewContract?.setCount(count)
+    }
+
+    override fun onAttach(viewContract: ViewContract) {
+        if (viewContract != this.viewContract) {
+            this.viewContract = viewContract as ViewDetailsContract
+            Log.d(tag, "$viewContract -> View прицепилась <<<<<<<<<<<<<<<<<<<<")
+        } else
+            Log.d(tag, "View прицепилась как новая <<<<<<<<<<<<<<")
+    }
+
+    override fun onDetach(viewContract: ViewContract) {
+        if (viewContract as ViewDetailsContract == this.viewContract) {
+            this.viewContract = null
+            Log.d(tag, "$viewContract -> View обнулилась <<<<<<<<<<<<<<<<<<<<")
+        } else
+            Log.d(tag, "$viewContract -> View НЕ обнулилась <<<<<<<<<<<<<<<<<<<<")
     }
 }

--- a/app/src/main/java/q4/test_coverage/mytests/presenter/search/SearchPresenter.kt
+++ b/app/src/main/java/q4/test_coverage/mytests/presenter/search/SearchPresenter.kt
@@ -1,50 +1,71 @@
 package q4.test_coverage.mytests.presenter.search
 
+import android.util.Log
 import q4.test_coverage.mytests.model.SearchResponse
 import q4.test_coverage.mytests.repository.GitHubRepository
 import q4.test_coverage.mytests.repository.GitHubRepository.GitHubRepositoryCallback
+import q4.test_coverage.mytests.view.ViewContract
 import q4.test_coverage.mytests.view.search.ViewSearchContract
 import retrofit2.Response
 
 /**
  * В архитектуре MVP все запросы на получение данных адресуются в Репозиторий.
- * Запросы могут проходить через Interactor или UseCase, использовать источники
+ * Запросы могут проходить через InterActor или UseCase, использовать источники
  * данных (DataSource), но суть от этого не меняется.
  * Непосредственно Презентер отвечает за управление потоками запросов и ответов,
  * выступая в роли регулировщика движения на перекрестке.
  */
 
 internal class SearchPresenter internal constructor(
-    private val viewContract: ViewSearchContract,
     private val repository: GitHubRepository
 ) : PresenterSearchContract, GitHubRepositoryCallback {
 
+    private val tag = "myLogs"
+
+    private var viewContract: ViewSearchContract? = null
+
     override fun searchGitHub(searchQuery: String) {
-        viewContract.displayLoading(true)
+        viewContract?.displayLoading(true)
         repository.searchGithub(searchQuery, this)
     }
 
+    override fun onAttach(viewContract: ViewContract) {
+        if (viewContract != this.viewContract) {
+            this.viewContract = viewContract as ViewSearchContract
+            Log.d(tag, "$viewContract -> View прицепилась <<<<<<<<<<<<<<<<<<<<")
+        } else
+            Log.d(tag, "View прицепилась как новая <<<<<<<<<<<<<<")
+    }
+
+    override fun onDetach(viewContract: ViewContract) {
+        if (viewContract as ViewSearchContract == this.viewContract) {
+            this.viewContract = null
+            Log.d(tag, "$viewContract -> View обнулилась <<<<<<<<<<<<<<<<<<<<")
+        } else
+            Log.d(tag, "$viewContract -> View НЕ обнулилась <<<<<<<<<<<<<<<<<<<<")
+    }
+
     override fun handleGitHubResponse(response: Response<SearchResponse?>?) {
-        viewContract.displayLoading(false)
+        viewContract?.displayLoading(false)
         if (response != null && response.isSuccessful) {
             val searchResponse = response.body()
             val searchResults = searchResponse?.searchResults
             val totalCount = searchResponse?.totalCount
             if (searchResults != null && totalCount != null) {
-                viewContract.displaySearchResults(
+                viewContract?.displaySearchResults(
                     searchResults,
                     totalCount
                 )
             } else {
-                viewContract.displayError("Search results or total count are null")
+                viewContract?.displayError("Search results or total count are null")
             }
         } else {
-            viewContract.displayError("Response is null or unsuccessful")
+            viewContract?.displayError("Response is null or unsuccessful")
         }
     }
 
     override fun handleGitHubError() {
-        viewContract.displayLoading(false)
-        viewContract.displayError()
+        viewContract?.displayLoading(false)
+        viewContract?.displayError()
     }
 }

--- a/app/src/main/java/q4/test_coverage/mytests/presenter/search/SearchPresenter.kt
+++ b/app/src/main/java/q4/test_coverage/mytests/presenter/search/SearchPresenter.kt
@@ -1,6 +1,5 @@
 package q4.test_coverage.mytests.presenter.search
 
-import android.util.Log
 import q4.test_coverage.mytests.model.SearchResponse
 import q4.test_coverage.mytests.repository.GitHubRepository
 import q4.test_coverage.mytests.repository.GitHubRepository.GitHubRepositoryCallback
@@ -29,20 +28,23 @@ internal class SearchPresenter internal constructor(
         repository.searchGithub(searchQuery, this)
     }
 
+    /** Скрываю логирование, т.к. в тестах они не проходят */
     override fun onAttach(viewContract: ViewContract) {
         if (viewContract != this.viewContract) {
             this.viewContract = viewContract as ViewSearchContract
-            Log.d(tag, "$viewContract -> View прицепилась <<<<<<<<<<<<<<<<<<<<")
-        } else
-            Log.d(tag, "View прицепилась как новая <<<<<<<<<<<<<<")
+            //   Log.d(tag, "$viewContract -> View прицепилась <<<<<<<<<<<<<<<<<<<<")
+            // } else
+            //   Log.d(tag, "View прицепилась как новая <<<<<<<<<<<<<<")
+        }
     }
 
     override fun onDetach(viewContract: ViewContract) {
         if (viewContract as ViewSearchContract == this.viewContract) {
             this.viewContract = null
-            Log.d(tag, "$viewContract -> View обнулилась <<<<<<<<<<<<<<<<<<<<")
-        } else
-            Log.d(tag, "$viewContract -> View НЕ обнулилась <<<<<<<<<<<<<<<<<<<<")
+            //  Log.d(tag, "$viewContract -> View обнулилась <<<<<<<<<<<<<<<<<<<<")
+            //  } else
+            //  Log.d(tag, "$viewContract -> View НЕ обнулилась <<<<<<<<<<<<<<<<<<<<")
+        }
     }
 
     override fun handleGitHubResponse(response: Response<SearchResponse?>?) {

--- a/app/src/main/java/q4/test_coverage/mytests/view/details/DetailsActivity.kt
+++ b/app/src/main/java/q4/test_coverage/mytests/view/details/DetailsActivity.kt
@@ -12,10 +12,21 @@ import java.util.*
 
 class DetailsActivity : AppCompatActivity(), ViewDetailsContract {
 
-    private val presenter: PresenterDetailsContract = DetailsPresenter(this)
+    private val presenter: PresenterDetailsContract = DetailsPresenter()
 
     private var _binding: ActivityDetailsBinding? = null
     private val binding get() = _binding!!
+
+    /** В методах жиз. цикла onStart и onStop имплементим методы презентера :*/
+    override fun onStart() {
+        presenter.onAttach(this)
+        super.onStart()
+    }
+
+    override fun onStop() {
+        presenter.onDetach(this)
+        super.onStop()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/q4/test_coverage/mytests/view/search/MainActivity.kt
+++ b/app/src/main/java/q4/test_coverage/mytests/view/search/MainActivity.kt
@@ -23,8 +23,19 @@ class MainActivity : AppCompatActivity(), ViewSearchContract {
     private val binding get() = _binding!!
 
     private val adapter = SearchResultAdapter()
-    private val presenter: PresenterSearchContract = SearchPresenter(this, createRepository())
+    private val presenter: PresenterSearchContract = SearchPresenter(createRepository())
     private var totalCount: Int = 0
+
+    /** В методах жиз. цикла onStart и onStop имплементим методы презентера :*/
+    override fun onStart() {
+        presenter.onAttach(this)
+        super.onStart()
+    }
+
+    override fun onStop() {
+        presenter.onDetach(this)
+        super.onStop()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/test/java/q4/test_coverage/mytests/DetailsPresenterTest.kt
+++ b/app/src/test/java/q4/test_coverage/mytests/DetailsPresenterTest.kt
@@ -1,0 +1,69 @@
+package q4.test_coverage.mytests
+
+import android.os.Build
+import android.widget.TextView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import junit.framework.TestCase.assertEquals
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import q4.test_coverage.mytests.presenter.details.DetailsPresenter
+import q4.test_coverage.mytests.view.details.DetailsActivity
+
+private const val justValue = 55
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.O_MR1])
+class DetailsPresenterTest {
+
+    private lateinit var scenario: ActivityScenario<DetailsActivity>
+    private lateinit var presenter: DetailsPresenter
+
+    @Before
+    fun setUp() {
+        scenario = ActivityScenario.launch(DetailsActivity::class.java)
+        presenter = DetailsPresenter()
+        scenario.onActivity {
+            presenter.onAttach(it)
+        }
+    }
+
+    @After
+    fun onDetach_closeScenario() {
+        scenario.onActivity {
+            presenter.onDetach(it)
+        }
+        scenario.close()
+    }
+
+    @Test
+    fun setCounter_View_TestSuccess() {
+        presenter.setCounter(justValue)
+        presenter.onIncrement()
+        scenario.onActivity {
+            val totalCountTextView = it.findViewById<TextView>(R.id.totalCountTextView)
+            assertEquals("Number of results: 56", totalCountTextView.text)
+        }
+    }
+
+    @Test
+    fun onIncrement_View_TestSuccess() {
+        presenter.onIncrement()
+        scenario.onActivity {
+            val totalCountTextView = it.findViewById<TextView>(R.id.totalCountTextView)
+            assertEquals("Number of results: 1", totalCountTextView.text)
+        }
+    }
+
+    @Test
+    fun onDecrement_View_TestSuccess() {
+        presenter.onDecrement()
+        scenario.onActivity {
+            val totalCountTextView = it.findViewById<TextView>(R.id.totalCountTextView)
+            assertEquals("Number of results: -1", totalCountTextView.text)
+        }
+    }
+}

--- a/app/src/test/java/q4/test_coverage/mytests/SearchPresenterTest.kt
+++ b/app/src/test/java/q4/test_coverage/mytests/SearchPresenterTest.kt
@@ -1,16 +1,17 @@
 package q4.test_coverage.mytests
 
-import q4.test_coverage.mytests.model.SearchResponse
-import q4.test_coverage.mytests.model.SearchResult
-import q4.test_coverage.mytests.presenter.search.SearchPresenter
-import q4.test_coverage.mytests.repository.GitHubRepository
-import q4.test_coverage.mytests.view.search.ViewSearchContract
+import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.MockitoAnnotations
+import q4.test_coverage.mytests.model.SearchResponse
+import q4.test_coverage.mytests.model.SearchResult
+import q4.test_coverage.mytests.presenter.search.SearchPresenter
+import q4.test_coverage.mytests.repository.GitHubRepository
+import q4.test_coverage.mytests.view.search.ViewSearchContract
 import retrofit2.Response
 
 //Тестируем наш Презентер
@@ -30,7 +31,30 @@ class SearchPresenterTest {
         //Раньше было @RunWith(MockitoJUnitRunner.class) в аннотации к самому классу (SearchPresenterTest)
         MockitoAnnotations.initMocks(this)
         //Создаем Презентер, используя моки Репозитория и Вью, проинициализированные строкой выше
-        presenter = SearchPresenter(viewContract, repository)
+        presenter = SearchPresenter(repository)
+        presenter.onAttach(viewContract)
+    }
+
+    /** Тестируем методы onAttach и onDetach.
+     * Но после каждого теста отцепляем viewContract
+     * */
+    @After
+    fun onDetach_ViewContract() {
+        presenter.onDetach(viewContract)
+    }
+
+    @Test
+    fun onAttach_View_Test() {
+        presenter.searchGitHub("some")
+        verify(viewContract).displayLoading(true)
+    }
+
+    @Test
+    fun onDetach_View_Test() {
+        /** Проверяем, чтобы не было с вьюхой никаких действий */
+        presenter.onDetach(viewContract)
+        presenter.searchGitHub("some")
+        verify(viewContract, times(0)).displayLoading(true)
     }
 
     @Test //Проверим вызов метода searchGitHub() у нашего Репозитория
@@ -44,6 +68,7 @@ class SearchPresenterTest {
 
     @Test //Проверяем работу метода handleGitHubError()
     fun handleGitHubError_Test() {
+        //viewContract = mock(ViewContract::class.java) as ViewSearchContract
         //Вызываем у Презентера метод handleGitHubError()
         presenter.handleGitHubError()
         //Проверяем, что у viewContract вызывается метод displayError()


### PR DESCRIPTION
1) Добавил методы onAttach и onDetach в интерфейс PresenterContract. Имплементировал эти методы в обоих презентерах и написал логику по прикручиванию соответствующих View к презентеру. А в активити мы просто вызываем методы onAttach и onDetach в жизненных циклах onStart и onStop.Теперь все Презентеры учитывают жизненный цикл View, который они хранят. 

Также в DetailsPresenter теперь viewContract: ViewDetailsContract? = null. И в методе onAttach мы цепляем, а в onDetach зануляем.

2) Покрыл тестами DetailsPresenter.

3) Покрыл тестами методы onAttach и onDetach в SearchPresenter. Для этого теперь перед каждым тестом цепляем viewContract в методе onAttach. Также скрыл Log.d, т.к. с ним не проходят тесты.